### PR TITLE
Replace CRC32 with SHA-256 in oml-merge

### DIFF
--- a/oml-tools/oml-merge/src/test/java/OmlMergeTests.java
+++ b/oml-tools/oml-merge/src/test/java/OmlMergeTests.java
@@ -1,5 +1,8 @@
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -140,6 +143,18 @@ public class OmlMergeTests {
         Assert.assertTrue(differences.size() == 1);
         Set<Path> resultPaths = Files.walk(test4_output).collect(Collectors.toSet());
         Assert.assertTrue(resultPaths.size() == 7);
+    }
+    
+    @Test
+    public void testNormalizedHash() throws IOException {
+        Assert.assertEquals(normalizedHash("a"), normalizedHash("a"));
+        Assert.assertNotEquals(normalizedHash("a"), normalizedHash("b"));
+        Assert.assertEquals(normalizedHash("\na\nb\n"), normalizedHash("\r\na\r\nb\r\n"));
+        Assert.assertEquals(normalizedHash("\na\nb\n"), normalizedHash("\ra\rb\r"));
+    }
+    
+    private ByteBuffer normalizedHash(String input) throws IOException {
+        return ByteBuffer.wrap(OmlMergeApp.normalizedHash(new ByteArrayInputStream(input.getBytes(StandardCharsets.UTF_8))));
     }
 
     public static void deleteDirectoryRecursively(File dir) {


### PR DESCRIPTION
To determine file equality we were previously comparing their CRC32 checksums; this replaces that with a SHA-256 hash. Also, to be more robust when comparing files that are written to on different platforms we now normalize CRLF and CR line endings to LF.