### PR TITLE
Fix oml-bikeshed generated .bat script errors and make .sh script executable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,9 @@ subprojects {
 	apply from: "${rootDir}/gradle/maven-deployment.gradle"
 
 	sourceCompatibility = '11'
+	compileJava.options.encoding = 'UTF-8'
+	compileTestJava.options.encoding = 'UTF-8'
+	javadoc.options.encoding = 'UTF-8'
 
 	java {
 	    withJavadocJar()

--- a/oml-bikeshed/src/main/java/io/opencaesar/oml/bikeshed/Oml2BikeshedApp.xtend
+++ b/oml-bikeshed/src/main/java/io/opencaesar/oml/bikeshed/Oml2BikeshedApp.xtend
@@ -214,9 +214,6 @@ class Oml2BikeshedApp {
 		val scriptContents = new StringBuffer
 		val forceToken=if(force) "-f" else "--die-on=link-error"
 		scriptContents.append('''
-			cd "$(dirname "$0")"
-		''')
-		scriptContents.append('''
 			bikeshed «forceToken» spec index.bs
 		''')
 		for (ontology : inputOntologies) {
@@ -227,9 +224,17 @@ class Oml2BikeshedApp {
 			''')
 		}
 		val publishShFile = new File(outputFolderPath+File.separator+'publish.sh').canonicalFile
-		outputFiles.put(publishShFile, scriptContents.toString)
+		outputFiles.put(publishShFile, '''
+			#!/bin/sh
+			cd "$(dirname "$0")"
+			«scriptContents»
+		''')
 		val publishBatFile = new File(outputFolderPath+File.separator+'publish.bat').canonicalFile
-		outputFiles.put(publishBatFile, scriptContents.toString)
+		outputFiles.put(publishBatFile, '''
+			pushd "%~dp0"
+			«scriptContents»
+			popd
+		''')
 
 		// create the index file as bikeshed spec
 		val indexFile = new File(outputFolderPath+File.separator+'index.bs')
@@ -287,7 +292,9 @@ class Oml2BikeshedApp {
 			    out.close()
 			}
 		]
-
+		
+		publishShFile.setExecutable(true)
+		
 		LOGGER.info("=================================================================")
 		LOGGER.info("                          E N D")
 		LOGGER.info("=================================================================")

--- a/oml-bikeshed/src/main/java/io/opencaesar/oml/bikeshed/OmlUtils.java
+++ b/oml-bikeshed/src/main/java/io/opencaesar/oml/bikeshed/OmlUtils.java
@@ -78,7 +78,7 @@ public class OmlUtils {
 
 	public static String getCopyright(AnnotatedElement element) {
 		var value = getAnnotationStringValue(element, "dc:rights");
-		return ((value != null) ? value : "").replaceAll("\n", ""); 
+		return ((value != null) ? value : "").replaceAll("\\R", "");
 	}
 	
 	public static String getComment(AnnotatedElement element) {


### PR DESCRIPTION
 * Configure Java compiler to use UTF-8 encoding in Gradle script to allow compilation to work in environments where UTF-8 is not the default charset.
 * Fix oml-bikeshed copyright linebreak removal to strip all Unicode linebreak sequences, not just LF
 * Fix oml-bikeshed generated .bat script to use correct syntax for changing into the script's directory
 * Make oml-bikeshed generated .sh script executable